### PR TITLE
Add Ubuntu support

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -1,0 +1,19 @@
+name: Ansible Tests
+
+on: [push, pull_request]
+
+jobs:
+  ansible:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Ansible
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ansible
+      - name: Run Zabbix Agent playbook in check mode
+        run: |
+          ansible-playbook -i 'localhost,' -c local init_zabbix_agent.yml --check
+      - name: Run Zabbix Server playbook in check mode
+        run: |
+          ansible-playbook -i 'localhost,' -c local init_zabbix_server.yml --check

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # zabbix-ansible
-1. Install zabbix server and agent in Centos 7.x
+1. Install Zabbix server and agent on CentOS 7.x or Ubuntu 24.04
 2. Make sure close selinux
 3. Use postgres as the zabbix database 
 4. Agent default is active mode

--- a/roles/basic/tasks/main.yml
+++ b/roles/basic/tasks/main.yml
@@ -1,6 +1,16 @@
 ---
-- name: Install pip
-  yum: name=python-pip state=present
+- name: Install pip on RedHat
+  yum:
+    name: python-pip
+    state: present
+  when: ansible_os_family == 'RedHat'
+
+- name: Install pip on Debian
+  apt:
+    name: python3-pip
+    state: present
+    update_cache: yes
+  when: ansible_os_family == 'Debian'
      
 - name: Install python expect
   pip:

--- a/roles/clean_zabbix_agent/tasks/debian_agent.yml
+++ b/roles/clean_zabbix_agent/tasks/debian_agent.yml
@@ -1,0 +1,14 @@
+---
+- name: Stop Zabbix Agent
+  systemd:
+    name: "{{ zabbix_agent_service }}"
+    state: stopped
+  ignore_errors: true
+
+- name: Remove Zabbix
+  apt:
+    name: zabbix-agent
+    state: absent
+    purge: yes
+    update_cache: yes
+  ignore_errors: true

--- a/roles/clean_zabbix_agent/tasks/main.yml
+++ b/roles/clean_zabbix_agent/tasks/main.yml
@@ -3,4 +3,8 @@
   include: redhat_agent.yml
   when: ansible_os_family == 'RedHat'
 
+- name: Debian
+  include: debian_agent.yml
+  when: ansible_os_family == 'Debian'
+
 

--- a/roles/init_zabbix_agent/tasks/debian_agent.yml
+++ b/roles/init_zabbix_agent/tasks/debian_agent.yml
@@ -1,0 +1,8 @@
+---
+- name: Install Zabbix Agent
+  include: install_zabbix_agent_debian.yml
+  when: install
+
+- name: Config Zabbix agent
+  include: config_zabbix_agent.yml
+  when: config

--- a/roles/init_zabbix_agent/tasks/install_zabbix_agent_debian.yml
+++ b/roles/init_zabbix_agent/tasks/install_zabbix_agent_debian.yml
@@ -1,0 +1,11 @@
+---
+- name: Update apt cache
+  apt:
+    update_cache: yes
+
+- name: Install Zabbix Agent
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "{{ zabbix_agent_install }}"

--- a/roles/init_zabbix_agent/tasks/main.yml
+++ b/roles/init_zabbix_agent/tasks/main.yml
@@ -2,3 +2,7 @@
 - name: Redhat
   include: redhat_agent.yml
   when: ansible_os_family == 'RedHat'
+
+- name: Debian
+  include: debian_agent.yml
+  when: ansible_os_family == 'Debian'

--- a/roles/init_zabbix_server/tasks/config_zabbix_server.yml
+++ b/roles/init_zabbix_server/tasks/config_zabbix_server.yml
@@ -4,7 +4,16 @@
   template: src=zabbix_server.conf dest={{zabbix_conf_path}} mode="u=rw,g=r,o=r"
 
 - name: Template Zabbix Web Conf
-  template: src=zabbix_httpd.conf dest=/etc/httpd/conf.d/zabbix.conf
+  template:
+    src: zabbix_httpd.conf
+    dest: /etc/httpd/conf.d/zabbix.conf
+  when: ansible_os_family == 'RedHat'
+
+- name: Template Zabbix Web Conf on Debian
+  template:
+    src: zabbix_httpd.conf
+    dest: /etc/apache2/conf-enabled/zabbix.conf
+  when: ansible_os_family == 'Debian'
   
 
 

--- a/roles/init_zabbix_server/tasks/debian_server.yml
+++ b/roles/init_zabbix_server/tasks/debian_server.yml
@@ -1,0 +1,8 @@
+---
+- name: Install Zabbix Server
+  include: install_zabbix_server_debian.yml
+  when: install
+
+- name: Config Zabbix Server
+  include: config_zabbix_server.yml
+  when: config

--- a/roles/init_zabbix_server/tasks/install_zabbix_server_debian.yml
+++ b/roles/init_zabbix_server/tasks/install_zabbix_server_debian.yml
@@ -1,0 +1,22 @@
+---
+- name: Update apt cache
+  apt:
+    update_cache: yes
+
+- name: Install Zabbix packages
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "{{ zabbix_server_install }}"
+
+- name: Install python expect
+  pip:
+    name: pexpect
+
+- name: Init Zabbix Server Postgres Database
+  expect:
+    command: /bin/bash -c "zcat /usr/share/doc/zabbix-server-pgsql*/create.sql.gz | psql -U {{db_user}} -h {{db_host}} {{db_name}}"
+    responses:
+      (?i)Password: '{{db_password}}'
+  when: "db_type == 'postgres'"

--- a/roles/init_zabbix_server/tasks/main.yml
+++ b/roles/init_zabbix_server/tasks/main.yml
@@ -2,3 +2,7 @@
 - name: Redhat
   include: redhat_server.yml
   when: ansible_os_family == 'RedHat'
+
+- name: Debian
+  include: debian_server.yml
+  when: ansible_os_family == 'Debian'

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -1,6 +1,19 @@
 ---
 - name: Get Postgres RPM
-  yum: name={{postgres_rpm_url}} state=present
+  yum:
+    name: "{{ postgres_rpm_url }}"
+    state: present
+  when: ansible_os_family == 'RedHat'
  
-- name: Install postgres client
-  yum: name={{postgres_client}} state=present
+- name: Install postgres client on RedHat
+  yum:
+    name: "{{ postgres_client }}"
+    state: present
+  when: ansible_os_family == 'RedHat'
+
+- name: Install postgres client on Debian
+  apt:
+    name: "{{ postgres_client | default('postgresql-client') }}"
+    state: present
+    update_cache: yes
+  when: ansible_os_family == 'Debian'

--- a/vars/zabbix_agent.yml
+++ b/vars/zabbix_agent.yml
@@ -8,7 +8,6 @@ user_parameter_list:
 zabbix_script_list:
    - "http_monitor.py"
 
-
 #installation of zabbix
 zabbix_agent_install:
   - "zabbix-agent"
@@ -19,5 +18,5 @@ server_active_ip: 172.16.251.75
 #refress time
 refresh_active_checks: 60
 
-services: 
+services:
   - 'zabbix-agent'


### PR DESCRIPTION
## Summary
- support Ubuntu hosts in README
- handle pip install on Debian
- manage Debian packages for Zabbix agent/server
- update PostgreSQL client role
- add workflow running playbooks in check mode

## Testing
- `ansible-playbook init_zabbix_agent.yml --syntax-check`
- `ansible-playbook init_zabbix_server.yml --syntax-check`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684174b1a1b08328b735af4120c3e454