### PR TITLE
Add proxy role with MariaDB and user management

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -1,0 +1,22 @@
+name: Ansible Tests
+
+on: [push, pull_request]
+
+jobs:
+  ansible:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Ansible
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ansible
+      - name: Run Zabbix Agent playbook
+        run: |
+          ansible-playbook -i ci_hosts init_zabbix_agent.yml
+      - name: Run Zabbix Server playbook
+        run: |
+          ansible-playbook -i ci_hosts init_zabbix_server.yml
+      - name: Run Zabbix Proxy playbook
+        run: |
+          ansible-playbook -i ci_hosts init_zabbix_proxy.yml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # zabbix-ansible
-1. Install zabbix server and agent in Centos 7.x
+1. Install Zabbix server and agent on CentOS 7.x or Ubuntu 24.04
 2. Make sure close selinux
 3. Use postgres as the zabbix database 
 4. Agent default is active mode
@@ -14,9 +14,11 @@ zabbix_user: zabbix
 zabbix_group: zabbix
 
 #rpm key of zabbix
-zabbix_key_url: "http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX"
+zabbix_key_url: "https://repo.zabbix.com/zabbix-official-repo.key"
 #rpm of zabbix
 zabbix_rpm_url: "http://repo.zabbix.com/zabbix/3.4/rhel/7/x86_64/zabbix-release-3.4-2.el7.noarch.rpm" # this is the zabbix version 3.4.2 is the latest version
+zabbix_apt_release: "{{ 'jammy' if ansible_distribution_release == 'noble' else ansible_distribution_release }}"
+zabbix_apt_repo: "deb https://repo.zabbix.com/zabbix/7.0/ubuntu {{ zabbix_apt_release }} main"
 
 # service port
 service_ports:
@@ -171,5 +173,14 @@ Now you can run like:
 ansible-playbook -i hosts init_zabbix_agent.yml
 ```
 
+## Install Zabbix Proxy
+Update `vars/zabbix_proxy.yml` to set your MariaDB credentials, then run:
+
+```
+ansible-playbook -i hosts init_zabbix_proxy.yml
+```
+
+The proxy installs MariaDB 11.4, creates the Zabbix database and user, and starts the proxy and agent services.
+
 ## License
-source code is licensed under the Apache Licence, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.html).
+Source code is licensed under the Apache Licence, Version 2.0 (<http://www.apache.org/licenses/LICENSE-2.0.html>).

--- a/ci_hosts
+++ b/ci_hosts
@@ -1,0 +1,8 @@
+[zabbix_server]
+localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3
+
+[zabbix_agent]
+localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3
+
+[zabbix_proxy]
+localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3

--- a/init_zabbix_proxy.yml
+++ b/init_zabbix_proxy.yml
@@ -1,0 +1,12 @@
+---
+- name: Init Zabbix Proxy
+  hosts: zabbix_proxy
+  vars_files:
+    - vars/zabbix_basic.yml
+    - vars/zabbix_proxy.yml
+  user: root
+  roles:
+    - mariadb
+    - zabbix_proxy
+    - init_zabbix_agent
+    - users

--- a/roles/basic/tasks/main.yml
+++ b/roles/basic/tasks/main.yml
@@ -1,6 +1,16 @@
 ---
-- name: Install pip
-  yum: name=python-pip state=present
+- name: Install pip on RedHat
+  yum:
+    name: python-pip
+    state: present
+  when: ansible_os_family == 'RedHat'
+
+- name: Install pip on Debian
+  apt:
+    name: python3-pip
+    state: present
+    update_cache: yes
+  when: ansible_os_family == 'Debian'
      
 - name: Install python expect
   pip:

--- a/roles/clean_zabbix_agent/tasks/debian_agent.yml
+++ b/roles/clean_zabbix_agent/tasks/debian_agent.yml
@@ -1,0 +1,14 @@
+---
+- name: Stop Zabbix Agent
+  systemd:
+    name: "{{ zabbix_agent_service }}"
+    state: stopped
+  ignore_errors: true
+
+- name: Remove Zabbix
+  apt:
+    name: zabbix-agent
+    state: absent
+    purge: yes
+    update_cache: yes
+  ignore_errors: true

--- a/roles/clean_zabbix_agent/tasks/main.yml
+++ b/roles/clean_zabbix_agent/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
 - name: Redhat
-  include: redhat_agent.yml
+  import_tasks: redhat_agent.yml
   when: ansible_os_family == 'RedHat'
+
+- name: Debian
+  import_tasks: debian_agent.yml
+  when: ansible_os_family == 'Debian'
 
 

--- a/roles/init_zabbix_agent/tasks/config_zabbix_agent.yml
+++ b/roles/init_zabbix_agent/tasks/config_zabbix_agent.yml
@@ -3,5 +3,5 @@
   template: src=zabbix_agentd.conf dest={{zabbix_conf_path}} mode="u=rw,g=r,o=r"
 
 - name: Init Script
-  include: init_script.yml
+  import_tasks: init_script.yml
   when: need_script

--- a/roles/init_zabbix_agent/tasks/debian_agent.yml
+++ b/roles/init_zabbix_agent/tasks/debian_agent.yml
@@ -1,9 +1,8 @@
 ---
 - name: Install Zabbix Agent
-  import_tasks: install_zabbix_agent.yml
+  import_tasks: install_zabbix_agent_debian.yml
   when: install
 
 - name: Config Zabbix agent
   import_tasks: config_zabbix_agent.yml
   when: config
-

--- a/roles/init_zabbix_agent/tasks/install_zabbix_agent_debian.yml
+++ b/roles/init_zabbix_agent/tasks/install_zabbix_agent_debian.yml
@@ -1,0 +1,25 @@
+---
+- name: Update apt cache
+  apt:
+    update_cache: yes
+
+- name: Add Zabbix apt key
+  apt_key:
+    url: "{{ zabbix_key_url }}"
+    state: present
+
+- name: Add Zabbix repository
+  apt_repository:
+    repo: "{{ zabbix_apt_repo }}"
+    state: present
+
+- name: Update apt cache after adding repo
+  apt:
+    update_cache: yes
+
+- name: Install Zabbix Agent
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "{{ zabbix_agent_install }}"

--- a/roles/init_zabbix_agent/tasks/main.yml
+++ b/roles/init_zabbix_agent/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
 - name: Redhat
-  include: redhat_agent.yml
+  import_tasks: redhat_agent.yml
   when: ansible_os_family == 'RedHat'
+
+- name: Debian
+  import_tasks: debian_agent.yml
+  when: ansible_os_family == 'Debian'

--- a/roles/init_zabbix_server/tasks/config_zabbix_server.yml
+++ b/roles/init_zabbix_server/tasks/config_zabbix_server.yml
@@ -4,7 +4,16 @@
   template: src=zabbix_server.conf dest={{zabbix_conf_path}} mode="u=rw,g=r,o=r"
 
 - name: Template Zabbix Web Conf
-  template: src=zabbix_httpd.conf dest=/etc/httpd/conf.d/zabbix.conf
+  template:
+    src: zabbix_httpd.conf
+    dest: /etc/httpd/conf.d/zabbix.conf
+  when: ansible_os_family == 'RedHat'
+
+- name: Template Zabbix Web Conf on Debian
+  template:
+    src: zabbix_httpd.conf
+    dest: /etc/apache2/conf-enabled/zabbix.conf
+  when: ansible_os_family == 'Debian'
   
 
 

--- a/roles/init_zabbix_server/tasks/debian_server.yml
+++ b/roles/init_zabbix_server/tasks/debian_server.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install Zabbix Server
-  import_tasks: install_zabbix_server.yml
+  import_tasks: install_zabbix_server_debian.yml
   when: install
 
 - name: Config Zabbix Server

--- a/roles/init_zabbix_server/tasks/install_zabbix_server_debian.yml
+++ b/roles/init_zabbix_server/tasks/install_zabbix_server_debian.yml
@@ -1,0 +1,36 @@
+---
+- name: Update apt cache
+  apt:
+    update_cache: yes
+
+- name: Add Zabbix apt key
+  apt_key:
+    url: "{{ zabbix_key_url }}"
+    state: present
+
+- name: Add Zabbix repository
+  apt_repository:
+    repo: "{{ zabbix_apt_repo }}"
+    state: present
+
+- name: Update apt cache after adding repo
+  apt:
+    update_cache: yes
+
+- name: Install Zabbix packages
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "{{ zabbix_server_install }}"
+
+- name: Install python expect
+  pip:
+    name: pexpect
+
+- name: Init Zabbix Server Postgres Database
+  expect:
+    command: /bin/bash -c "zcat /usr/share/doc/zabbix-server-pgsql*/create.sql.gz | psql -U {{db_user}} -h {{db_host}} {{db_name}}"
+    responses:
+      (?i)Password: '{{db_password}}'
+  when: "db_type == 'postgres'"

--- a/roles/init_zabbix_server/tasks/main.yml
+++ b/roles/init_zabbix_server/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
 - name: Redhat
-  include: redhat_server.yml
+  import_tasks: redhat_server.yml
   when: ansible_os_family == 'RedHat'
+
+- name: Debian
+  import_tasks: debian_server.yml
+  when: ansible_os_family == 'Debian'

--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+zabbix_db: zabbix
+zabbix_db_user: zabbix
+zabbix_db_password: zabbix
+zabbix_db_host: localhost

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+- name: Add MariaDB apt key
+  apt_key:
+    url: https://mariadb.org/mariadb_release_signing_key.asc
+    state: present
+
+- name: Add MariaDB repository
+  apt_repository:
+    repo: "deb [arch=amd64] http://mirror.mariadb.org/repo/11.4/ubuntu {{ ansible_distribution_release }} main"
+    state: present
+
+- name: Update apt cache
+  apt:
+    update_cache: yes
+
+- name: Install MariaDB packages
+  apt:
+    name: mariadb-server
+    state: present
+
+- name: Ensure MariaDB service is running
+  service:
+    name: mariadb
+    state: started
+    enabled: yes
+
+- name: Create Zabbix database
+  mysql_db:
+    name: "{{ zabbix_db }}"
+    state: present
+
+- name: Ensure Zabbix DB user
+  mysql_user:
+    name: "{{ zabbix_db_user }}"
+    password: "{{ zabbix_db_password }}"
+    priv: "{{ zabbix_db }}.*:ALL"
+    host: "{{ zabbix_db_host | default('localhost') }}"
+    state: present

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -1,6 +1,19 @@
 ---
 - name: Get Postgres RPM
-  yum: name={{postgres_rpm_url}} state=present
+  yum:
+    name: "{{ postgres_rpm_url }}"
+    state: present
+  when: ansible_os_family == 'RedHat'
  
-- name: Install postgres client
-  yum: name={{postgres_client}} state=present
+- name: Install postgres client on RedHat
+  yum:
+    name: "{{ postgres_client }}"
+    state: present
+  when: ansible_os_family == 'RedHat'
+
+- name: Install postgres client on Debian
+  apt:
+    name: "{{ postgres_client | default('postgresql-client') }}"
+    state: present
+    update_cache: yes
+  when: ansible_os_family == 'Debian'

--- a/roles/users/defaults/main.yml
+++ b/roles/users/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+users_add: []
+users_disable: []
+users_remove: []

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: Add users
+  user:
+    name: "{{ item.name }}"
+    state: present
+    groups: "{{ 'sudo' if item.sudo | default(false) else '' }}"
+    create_home: yes
+  with_items: "{{ users_add | default([]) }}"
+
+- name: Deploy SSH keys for new users
+  authorized_key:
+    user: "{{ item.name }}"
+    key: "{{ item.ssh_key }}"
+  with_items: "{{ users_add | default([]) }}"
+  when: item.ssh_key is defined
+
+- name: Disable users
+  user:
+    name: "{{ item }}"
+    password_lock: yes
+  with_items: "{{ users_disable | default([]) }}"
+
+- name: Remove users
+  user:
+    name: "{{ item }}"
+    state: absent
+    remove: yes
+  with_items: "{{ users_remove | default([]) }}"

--- a/roles/zabbix_proxy/handlers/main.yml
+++ b/roles/zabbix_proxy/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart Zabbix proxy
+  service:
+    name: zabbix-proxy
+    state: restarted

--- a/roles/zabbix_proxy/tasks/main.yml
+++ b/roles/zabbix_proxy/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+- name: Add Zabbix apt key
+  apt_key:
+    url: "{{ zabbix_key_url }}"
+    state: present
+
+- name: Add Zabbix repository
+  apt_repository:
+    repo: "{{ zabbix_apt_repo }}"
+    state: present
+
+- name: Update apt cache
+  apt:
+    update_cache: yes
+
+- name: Install Zabbix proxy package
+  apt:
+    name: zabbix-proxy-mysql
+    state: present
+
+- name: Configure Zabbix proxy
+  template:
+    src: zabbix_proxy.conf.j2
+    dest: /etc/zabbix/zabbix_proxy.conf
+  notify: Restart Zabbix proxy
+
+- name: Ensure Zabbix proxy service
+  service:
+    name: zabbix-proxy
+    state: started
+    enabled: yes

--- a/roles/zabbix_proxy/templates/zabbix_proxy.conf.j2
+++ b/roles/zabbix_proxy/templates/zabbix_proxy.conf.j2
@@ -1,0 +1,4 @@
+### Managed by Ansible
+DBName={{ zabbix_db }}
+DBUser={{ zabbix_db_user }}
+DBPassword={{ zabbix_db_password }}

--- a/vars/zabbix_agent.yml
+++ b/vars/zabbix_agent.yml
@@ -8,7 +8,6 @@ user_parameter_list:
 zabbix_script_list:
    - "http_monitor.py"
 
-
 #installation of zabbix
 zabbix_agent_install:
   - "zabbix-agent"
@@ -19,5 +18,5 @@ server_active_ip: 172.16.251.75
 #refress time
 refresh_active_checks: 60
 
-services: 
+services:
   - 'zabbix-agent'

--- a/vars/zabbix_basic.yml
+++ b/vars/zabbix_basic.yml
@@ -7,9 +7,11 @@ zabbix_user: zabbix
 zabbix_group: zabbix
 
 #rpm key of zabbix
-zabbix_key_url: "http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX"
+zabbix_key_url: "https://repo.zabbix.com/zabbix-official-repo.key"
 #rpm of zabbix
 zabbix_rpm_url: "http://repo.zabbix.com/zabbix/3.4/rhel/7/x86_64/zabbix-release-3.4-2.el7.noarch.rpm"
+zabbix_apt_release: "{{ 'jammy' if ansible_distribution_release == 'noble' else ansible_distribution_release }}"
+zabbix_apt_repo: "deb https://repo.zabbix.com/zabbix/7.0/ubuntu {{ zabbix_apt_release }} main"
 
 # service port
 service_ports:

--- a/vars/zabbix_proxy.yml
+++ b/vars/zabbix_proxy.yml
@@ -1,0 +1,6 @@
+---
+# MariaDB credentials
+zabbix_db: zabbix
+zabbix_db_user: zabbix
+zabbix_db_password: zabbix
+zabbix_db_host: localhost


### PR DESCRIPTION
## Summary
- add Ansible role for MariaDB 11.4
- add role for Zabbix proxy on Ubuntu
- manage users via new `users` role
- create playbook to deploy proxy and agent
- test playbooks in CI workflow

## Testing
- `ansible-playbook init_zabbix_agent.yml --syntax-check`
- `ansible-playbook init_zabbix_server.yml --syntax-check`
- `ansible-playbook init_zabbix_proxy.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_684174b1a1b08328b735af4120c3e454